### PR TITLE
Update AWS bucket for resources and outputs

### DIFF
--- a/singlecluster-pipeline.yml
+++ b/singlecluster-pipeline.yml
@@ -41,18 +41,18 @@ resources:
 - name: singlecluster-HDP
   type: s3
   source:
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    bucket: {{pxf-aws-bucket-name}}
+    access_key_id: {{bucket-access-key-id}}
+    secret_access_key: {{bucket-secret-access-key}}
+    bucket: {{pxf-bucket-name}}
     region_name: {{aws-region}}
     versioned_file: singlecluster-without-pxf/singlecluster-HDP.tar.gz
 
 - name: singlecluster-CDH
   type: s3
   source:
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    bucket: {{pxf-aws-bucket-name}}
+    access_key_id: {{bucket-access-key-id}}
+    secret_access_key: {{bucket-secret-access-key}}
+    bucket: {{pxf-bucket-name}}
     region_name: {{aws-region}}
     versioned_file: singlecluster-without-pxf/singlecluster-CDH.tar.gz
 
@@ -66,9 +66,9 @@ resources:
 - name: hdp_tars_tarball
   type: s3
   source:
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    bucket: {{pxf-aws-bucket-name}}
+    access_key_id: {{bucket-access-key-id}}
+    secret_access_key: {{bucket-secret-access-key}}
+    bucket: {{pxf-bucket-name}}
     region_name: {{aws-region}}
     versioned_file: hortonworks/HDP-2.5.3.0-centos6-tars-tarball.tar.gz
 
@@ -76,42 +76,42 @@ resources:
 - name: cdh_tars_tarball
   type: s3
   source:
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    bucket: {{pxf-aws-bucket-name}}
+    access_key_id: {{bucket-access-key-id}}
+    secret_access_key: {{bucket-secret-access-key}}
+    bucket: {{pxf-bucket-name}}
     region_name: {{aws-region}}
     versioned_file: cloudera/CDH-5.10.2.tar.gz
 
 - name: jdbc
   type: s3
   source:
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    bucket: {{pxf-aws-bucket-name}}
+    access_key_id: {{bucket-access-key-id}}
+    secret_access_key: {{bucket-secret-access-key}}
+    bucket: {{pxf-bucket-name}}
     region_name: {{aws-region}}
     versioned_file: jdbc/postgresql-jdbc-8.4.704.jar
 
 - name: tomcat
   type: s3
   source:
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    bucket: {{pxf-aws-bucket-name}}
+    access_key_id: {{bucket-access-key-id}}
+    secret_access_key: {{bucket-secret-access-key}}
+    bucket: {{pxf-bucket-name}}
     region_name: {{aws-region}}
     versioned_file: tomcat/apache-tomcat-7.0.62.tar.gz
 
 - name: curl_bin_tarball
   type: s3
   source:
-    access_key_id: {{aws-access-key-id}}
-    secret_access_key: {{aws-secret-access-key}}
-    bucket: {{aws-bucket-name}}
+    access_key_id: {{bucket-access-key-id}}
+    secret_access_key: {{bucket-secret-access-key}}
+    bucket: {{pxf-bucket-name}}
     region_name: {{aws-region}}
-    versioned_file: hdb_dependencies/binaries/curl-7.50.3-bin.tgz
+    versioned_file: curl/curl-7.50.3-bin.tgz
 
 - name: maven_centos6_image
   type: docker-image
   source:
     repository: pivotaldata/maven-centos6
-    username: {{docker-username}}
-    password: {{docker-password}}
+    username: {{pxf-docker-username}}
+    password: {{pxf-docker-password}}


### PR DESCRIPTION
Moved resource artifacts and output tarballs from s3 bucket under hawq account
to gpdb5-pipeline account because singlecluster is only used by pxf at
the moment, and pxf is a gpdb5 extension.